### PR TITLE
Enhance start_service to load env vars and config

### DIFF
--- a/netbird/files/netbird.init
+++ b/netbird/files/netbird.init
@@ -15,9 +15,17 @@ start_service() {
 	local device
 
 	procd_open_instance
-	procd_set_param env $(test -e /etc/sysconfig/netbird && grep '^[^#]' </etc/sysconfig/netbird)
+
+	# 从 /etc/sysconfig/netbird 加载环境变量（过滤掉注释），并强制设置 HOME=/root
+	if [ -e /etc/sysconfig/netbird ]; then
+		procd_set_param env $(grep '^[^#]' </etc/sysconfig/netbird) HOME=/root
+	else
+		procd_set_param env HOME=/root
+	fi
+
+	# 启动 NetBird 服务
 	procd_set_param command /usr/bin/netbird
-	procd_append_param command service run
+	procd_append_param command service run --config /etc/netbird/config.json
 	procd_set_param pidfile /var/run/netbird.pid
 	procd_close_instance
 }


### PR DESCRIPTION
Updated the start_service function to load environment variables from /etc/sysconfig/netbird and set HOME=/root. Modified command to include configuration file.